### PR TITLE
Fixes #15 and #17 issues related to default/other assemblies

### DIFF
--- a/src/main/java/org/monarchinitiative/omop/command/GenomicDataCommand.java
+++ b/src/main/java/org/monarchinitiative/omop/command/GenomicDataCommand.java
@@ -21,9 +21,10 @@ public abstract class GenomicDataCommand extends Command {
     protected Assembly assembly;
 
     @CommandLine.Option(names = "--database",
+            defaultValue = "ensembl",
             scope = CommandLine.ScopeType.INHERIT,
-            description = "database: ${COMPLETION-CANDIDATES}")
-    protected Vcf2OmopCommand.GenomeDatabase genomeDatabase = Vcf2OmopCommand.GenomeDatabase.ensembl;
+            description = "database: ${COMPLETION-CANDIDATES}, default ${DEFAULT-VALUE}")
+    protected Vcf2OmopCommand.GenomeDatabase genomeDatabase;
 
     @CommandLine.Option(names = {"-s", "--stage"},
             scope = CommandLine.ScopeType.INHERIT,

--- a/src/main/java/org/monarchinitiative/omop/command/GenomicDataCommand.java
+++ b/src/main/java/org/monarchinitiative/omop/command/GenomicDataCommand.java
@@ -15,9 +15,10 @@ import java.util.List;
  */
 public abstract class GenomicDataCommand extends Command {
     @CommandLine.Option(names = {"-a", "--assembly"},
+            defaultValue = "hg19",
             scope = CommandLine.ScopeType.INHERIT,
-            description = "genome assembly: ${COMPLETION-CANDIDATES}, default ${DEFAULT_VALUE}")
-    protected Assembly assembly = Assembly.GRCh19;
+            description = "genome assembly: ${COMPLETION-CANDIDATES}, default ${DEFAULT-VALUE}")
+    protected Assembly assembly;
 
     @CommandLine.Option(names = "--database",
             scope = CommandLine.ScopeType.INHERIT,
@@ -53,6 +54,7 @@ public abstract class GenomicDataCommand extends Command {
                 } else {
                     throw new Vcf2OmopRuntimeException("Could not identify databasae " + genomeDatabase);
                 }
+                break;
             default:
                 throw new Vcf2OmopRuntimeException("Could not identify assembly " + assembly.toString());
         }

--- a/src/main/java/org/monarchinitiative/omop/stage/OmopStagedVariant.java
+++ b/src/main/java/org/monarchinitiative/omop/stage/OmopStagedVariant.java
@@ -93,7 +93,7 @@ public class OmopStagedVariant {
             case "37":
             case "hg19":
             case "hg37":
-            case "CRCh37":
+            case "GRCh37":
                 return Assembly.GRCh19;
             case "38":
             case "hg38":


### PR DESCRIPTION
Adds a `defaultValue` parameter for the assembly command line option for hg19 and adds a `break` so hg38/GRCh38 can be identified.